### PR TITLE
[FEAT] Delegate last fm api calls to back

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -1,2 +1,1 @@
-LASTFM_API_KEY="your_key"
 PUBLIC_API_ENDPOINT="https://blabla.com"

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -5,16 +5,16 @@
   import {cursorEnter, cursorLeave} from '$lib/actions/cursor';
   import Magnetik from "$lib/components/Magnetik.svelte";
   import {toggleTheme} from "$lib/stores/themeStore";
-  import {RecentTrackSchema, type TRecentTrack} from "$lib/types/lastfm";
   import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+  import {BackendSongSchema, type TBackendSong} from "$lib/types/lastfm";
 
   // Bindings
   let button: HTMLButtonElement = $state();
   let isAnimating = false;
 
-  // State
-  let currentTrack: TRecentTrack | null = $state(null);
-  const isLive = $derived(!!currentTrack?.['@attr']?.nowplaying);
+  // Statee
+  let currentTrack: TBackendSong | null = $state(null);
+  const isLive = $derived(() => currentTrack?.currently_playing);
 
   // Functions
   const handleToggleTheme = () => {
@@ -69,7 +69,7 @@
     try {
       const response = await fetch("api/music/now-playing");
 
-      const parse = RecentTrackSchema.safeParse(await response.json());
+      const parse = BackendSongSchema.safeParse(await response.json());
 
       if (parse.success) {
         currentTrack = parse.data;
@@ -96,7 +96,7 @@
 
 <nav>
   <span class="now-playing">
-    {#if isLive && currentTrack}
+    {#if isLive() && currentTrack}
       <div
           in:fade={{duration: 500}}
           out:fade={{duration: 500}}
@@ -105,7 +105,7 @@
         <span class="text-sm">Live: </span>
       </div>
       <span class="track-info">
-        {currentTrack.name} - {currentTrack.artist['#text']}
+        {currentTrack.name} - {currentTrack.artist}
       </span>
     {/if}
   </span>

--- a/src/lib/stores/songStore.ts
+++ b/src/lib/stores/songStore.ts
@@ -4,47 +4,22 @@
  * @author Tom Planche
  */
 import {writable} from "svelte/store";
-import type {TRecentTrack, TRecentTrackWithCount} from "$lib/types/lastfm";
+import type {TBackendSong} from "$lib/types/lastfm";
 
 const songStore = () => {
   // Initialize with default theme '1'
-  const {subscribe, set} = writable<TRecentTrackWithCount[]>([]);
+  const {subscribe, set} = writable<TBackendSong[]>([]);
 
   return {
     subscribe,
-    set: (value: TRecentTrack[]) => {
+    set: (values: TBackendSong[]) => {
       // Filter out songs without an image URL or with default image
       // const filteredSongs = value.filter(song => {
       //   return song.image[song.image.length - 1]["#text"]
       //     && song.image[song.image.length - 1]["#text"] !== "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
       // });
 
-      // Create a map to count occurrences of each song
-      const songMap = new Map<string, TRecentTrackWithCount>();
-
-      for (const song of value) {
-        const key = `${song.name}-${song.artist["#text"]}`;
-
-        if (songMap.has(key)) {
-          const existing = songMap.get(key);
-
-          if (!existing) {
-            continue;
-          }
-
-          existing.count += 1;
-        } else {
-          songMap.set(key, {
-            ...song,
-            count: 1
-          });
-        }
-      }
-
-      // Convert map values to array
-      const uniqueSongsWithCount = Array.from(songMap.values());
-
-      set(uniqueSongsWithCount);
+      set(values);
     },
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,40 @@
+/**
+ * @file src/lib/types.ts
+ * @description types
+ * @author Tom Planche
+ */
+
+export type TCursor = {
+  isHover: boolean;
+  scale: number;
+  opacity: number;
+  svg: string;
+  innerText: string;
+  backgroundColor: string;
+  blur: number;
+};
+
+export type TCursorOptions = {
+  [key in keyof TCursor]?: TCursor[key];
+};
+
+
+export type ActionReturn<P> = {
+  update?: (newParams: P) => void;
+  destroy?: () => void;
+};
+
+export type Action<P = void> = (
+  node: HTMLElement,
+  params?: P
+) => ActionReturn<P> | void;
+
+// For components that can accept actions
+export type UseProps = {
+  action: Action;
+  props?: Record<string, unknown>;
+};
+
+/**
+ * End of file src/lib/types.ts
+ */

--- a/src/lib/types/lastfm.ts
+++ b/src/lib/types/lastfm.ts
@@ -69,7 +69,6 @@ export const RecentTrackSchema = BaseObjectSchema.extend({
 });
 
 export type TRecentTrack = z.infer<typeof RecentTrackSchema>;
-export type TRecentTrackWithCount = z.infer<typeof RecentTrackSchema> & { count: number };
 
 export const BaseResponseSchema = z.object({
   user: z.string(),
@@ -88,7 +87,33 @@ export const getRecentTracksSchema = z.object({
 
 export type TGetRecentTracks = z.infer<typeof getRecentTracksSchema>;
 
+/*
+[
+  {
+    "name": "Make You Move",
+    "play_count": 1,
+    "artist": "Carv",
+    "album": "Make You Move - Single",
+    "image_url": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png",
+    "currently_playing": true
+  }
+]
+ */
+export const BackendSongSchema = z.object({
+  name: z.string(),
+  play_count: z.number(),
+  artist: z.string(),
+  album: z.string(),
+  image_url: z.string(),
+  currently_playing: z.boolean(),
+  // date: 1740691900
+  date: z.union([
+    z.coerce.date(),
+    z.coerce.number().transform((v) => new Date(v * 1000)),
+  ]).optional()
+});
 
+export type TBackendSong = z.infer<typeof BackendSongSchema>;
 /**
  * End of file src/lib/types/lastfm.ts
  */

--- a/src/routes/api/music/+server.ts
+++ b/src/routes/api/music/+server.ts
@@ -4,13 +4,12 @@
  * @author Tom Planche
  */
 import {error, json, type RequestHandler} from "@sveltejs/kit";
-import {LASTFM_API_KEY} from "$env/static/private";
 import {getRecentTracks} from "$lib/utils/lastfm";
 
 export const GET: RequestHandler = async () => {
 
   try {
-    const songs = await getRecentTracks(100, LASTFM_API_KEY);
+    const songs = await getRecentTracks();
 
     return json(songs);
   } catch (e: unknown) {

--- a/src/routes/api/music/now-playing/+server.ts
+++ b/src/routes/api/music/now-playing/+server.ts
@@ -3,15 +3,14 @@
  * @description +server
  * @author Tom Planche
  */
-import {LASTFM_API_KEY} from "$env/static/private";
 import {error, json, type RequestHandler} from "@sveltejs/kit";
-import {getRecentTracks} from "$lib/utils/lastfm";
+import {getCurrentTrack} from "$lib/utils/lastfm";
 
 export const GET: RequestHandler = async () => {
   try {
-    const songs = await getRecentTracks(1, LASTFM_API_KEY);
+    const song = await getCurrentTrack();
 
-    return json(songs[0]);
+    return json(song);
   } catch (e: unknown) {
     return error(500, <App.Error>e)
   }

--- a/src/routes/music/+page.svelte
+++ b/src/routes/music/+page.svelte
@@ -2,10 +2,10 @@
   // Imports
   import {onMount} from "svelte";
   import {songsStore} from "$lib/stores/songStore";
-  import type {TRecentTrackWithCount} from "$lib/types/lastfm";
+  import type {TBackendSong} from "$lib/types/lastfm";
 
   // Variables
-  let songs = $state<TRecentTrackWithCount[]>([]);
+  let songs = $state<TBackendSong[]>([]);
 
   // Functions
   const formatPlayCount = (count: number): string => {
@@ -22,10 +22,12 @@
   // Lifecycle
   onMount(() => {
     // sort by date (.date.uts) but date can be undefined
-    songs = $songsStore.sort((a: TRecentTrackWithCount, b: TRecentTrackWithCount) => {
-      if (a.date?.uts && b.date?.uts) {
-        return a.date.uts.getDate() - b.date.uts.getDate();
+    songs = $songsStore.sort((a: TBackendSong, b: TBackendSong) => {
+      if (a.date && b.date) {
+        return a.date.getDate() - b.date.getDate();
       }
+
+      return 0;
     });
   });
 </script>
@@ -40,9 +42,9 @@
       >
         <div class="left">
           <img
-              src={song.image[song.image.length - 1]['#text']}
-              alt={song.album["#text"]}
-              title={song.album["#text"]}
+              src={song.image_url}
+              alt={song.album}
+              title={song.album}
           />
           <div class="infos">
             <h2
@@ -53,13 +55,13 @@
             </h2>
             <p
                 class="artist-name"
-                title={song.artist["#text"]}
+                title={song.artist}
             >
-              {song.artist["#text"]}
+              {song.artist}
             </p>
           </div>
         </div>
-        <span class="play-count">{formatPlayCount(song.count)}&nbsp;play{song.count > 1 ? 's' : ''}</span>
+        <span class="play-count">{formatPlayCount(song.play_count)}&nbsp;play{song.play_count > 1 ? 's' : ''}</span>
       </article>
     {/each}
   </div>

--- a/src/routes/music/+page.ts
+++ b/src/routes/music/+page.ts
@@ -6,15 +6,15 @@
 
 import type {PageLoad} from "./$types";
 import {songsStore} from "$lib/stores/songStore";
-import {RecentTrackSchema, type TRecentTrack, type TRecentTrackWithCount} from "$lib/types/lastfm";
+import {BackendSongSchema, type TBackendSong} from "$lib/types/lastfm";
 
 export const load: PageLoad = async ({fetch}) => {
   try {
     const songs = await fetch("/api/music", {
       method: "GET",
-    }).then(async (res) => await res.json() as TRecentTrack[]);
+    }).then(async (res) => await res.json() as TBackendSong[]);
 
-    songsStore.set(songs.map((song) => RecentTrackSchema.parse(song)));
+    songsStore.set(songs.map((song) => BackendSongSchema.parse(song)));
   } catch (e) {
     console.error(e);
 


### PR DESCRIPTION
 Handling the Last.fm fetches server-side periodically for avoiding loads of unnecessary requests (if lot of visitors :/).