### PR TITLE
[FEAT] Cleaner footer and header UI and code logic/syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ The website is automatically deployed using GitHub Actions. On every push to the
   
   *Inspired by the techniques described in [Interactive WebGL Backgrounds: A Quick Guide to Bayer Dithering](https://tympanus.net/codrops/2025/07/30/interactive-webgl-backgrounds-a-quick-guide-to-bayer-dithering/) on Codrops.*
 
+- [Scroll State Composable](./src/lib/composables/useScrollState.ts)
+
+  A reactive composable that elegantly tracks scroll state using Svelte 5's runes system. It monitors both the current scroll position and whether the page can be scrolled, then derives a boolean indicating if the scroll position has exceeded a defined trigger threshold. The composable automatically manages event listeners for scroll and resize events, providing a clean API for scroll-based UI changes like header styling or element visibility. Perfect for implementing smooth scroll-triggered animations and responsive design patterns.
+
 ## Backend Infrastructure
 The website is powered by two custom Rust services:
 

--- a/src/lib/components/header-footer/Footer.svelte
+++ b/src/lib/components/header-footer/Footer.svelte
@@ -1,30 +1,12 @@
 <script lang="ts">
   // Imports
   import { cursorEnter, cursorLeave } from "$lib/actions/cursor";
-  import { scrollTrigger } from "$lib/components/header-footer/index";
-
-  import { onMount } from "svelte";
+  import { useScrollState } from "$lib/composables/useScrollState";
 
   // Variables
   const e_m_a_i_l = "tom" + "planche" + "@" + "icloud.com";
 
-  // Scroll effect state
-  let scrollY = $state(0);
-  const isScrolled = $derived(scrollY >= scrollTrigger);
-
-  // Lifecycle
-  onMount(() => {
-    // Track scroll position
-    const handleScroll = () => {
-      scrollY = window.scrollY;
-    };
-
-    window.addEventListener("scroll", handleScroll);
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  });
+  const { isScrolled } = useScrollState();
 </script>
 
 <footer class:scrolled={isScrolled}>

--- a/src/lib/components/header-footer/Header.svelte
+++ b/src/lib/components/header-footer/Header.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
   import { cursorEnter, cursorLeave } from "$lib/actions/cursor";
   import LiveIndicator from "$lib/components/LiveIndicator.svelte";
-  import { scrollTrigger } from "$lib/components/header-footer/index"; // Statee
   import { BackendSongSchema, type TBackendSong } from "$lib/types/lastfm";
 
   import { onMount } from "svelte";
   import { fade } from "svelte/transition";
+  import { useScrollState } from "$lib/composables/useScrollState";
 
   // Statee
   let currentTrack: TBackendSong | null = $state(null);
   const isLive = $derived(() => currentTrack?.currently_playing);
 
   // Scroll effect state
-  let scrollY = $state(0);
-  const isScrolled = $derived(scrollY >= scrollTrigger);
+  const { isScrolled } = useScrollState();
 
   // Functions
   const fetchNowPlaying = async () => {
@@ -43,16 +42,8 @@
     // Refresh every 10 seconds
     const interval = setInterval(fetchNowPlaying, 10000);
 
-    // Track scroll position
-    const handleScroll = () => {
-      scrollY = window.scrollY;
-    };
-
-    window.addEventListener("scroll", handleScroll);
-
     return () => {
       clearInterval(interval);
-      window.removeEventListener("scroll", handleScroll);
     };
   });
 </script>

--- a/src/lib/composables/useScrollState.ts
+++ b/src/lib/composables/useScrollState.ts
@@ -1,0 +1,74 @@
+import { scrollTrigger } from "$lib/components/header-footer/index";
+import { onMount } from "svelte";
+
+/**
+ * Return type for the useScrollState composable
+ */
+interface UseScrollStateReturn {
+  readonly isScrolled: boolean;
+}
+
+/**
+ * A composable that tracks scroll state and determines if the page is scrolled beyond a trigger point.
+ *
+ * This composable provides reactive scroll state management using Svelte 5's runes system.
+ * It tracks the current scroll position and whether scrolling is possible on the page,
+ * then derives a boolean indicating if the scroll position has exceeded the defined trigger threshold.
+ *
+ * The composable automatically sets up and cleans up event listeners for:
+ * - `scroll` events to track vertical scroll position
+ * - `resize` events to recalculate scroll capabilities when window size changes
+ *
+ * @returns An object containing:
+ * - `isScrolled`: A reactive derived value that returns `true` when either:
+ *   - The page cannot be scrolled (content fits within viewport), OR
+ *   - The current scroll position is greater than or equal to the `scrollTrigger` value
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { useScrollState } from '$lib/composables/useScrollState';
+ *
+ *   const { isScrolled } = useScrollState();
+ * </script>
+ *
+ * <header class:scrolled={isScrolled}>
+ *   <!-- Header content that changes appearance when scrolled -->
+ * </header>
+ * ```
+ */
+export const useScrollState = (): UseScrollStateReturn => {
+  let scrollY: number = $state(0);
+  let canScroll: boolean = $state(false);
+  const isScrolled: boolean = $derived(!canScroll || scrollY >= scrollTrigger);
+
+  onMount(() => {
+    const updateScrollY = (): void => {
+      scrollY = window.scrollY;
+    };
+
+    const updateCanScroll = (): void => {
+      canScroll = document.documentElement.scrollHeight > window.innerHeight;
+    };
+
+    const updateAll = (): void => {
+      updateScrollY();
+      updateCanScroll();
+    };
+
+    // Initial update
+    updateAll();
+
+    window.addEventListener("scroll", updateScrollY);
+    window.addEventListener("resize", updateAll);
+
+    return (): void => {
+      window.removeEventListener("scroll", updateScrollY);
+      window.removeEventListener("resize", updateAll);
+    };
+  });
+
+  return {
+    isScrolled,
+  } as const;
+};


### PR DESCRIPTION
Both header and footer use `useScrollState` to apply rounded corners and inset positioning when the page is scrolled OR when the page cannot be scrolled (content fits within viewport).